### PR TITLE
When getting an image, scan through linked contacts for image

### DIFF
--- a/RCTAddressBook.m
+++ b/RCTAddressBook.m
@@ -167,9 +167,22 @@ withCallback:(RCTResponseSenderBlock) callback
 -(NSString *) getABPersonThumbnailFilepath:(ABRecordRef) person
 {
   if (ABPersonHasImageData(person)){
+
+    NSArray *linkedPersons = CFBridgingRelease(ABPersonCopyArrayOfAllLinkedPeople(person));
+    for (id obj in linkedPersons) {
+        ABRecordRef aLinkedPerson = (__bridge ABRecordRef)obj;
+        if (aLinkedPerson == person) {
+            continue; // skip the original one
+        }
+        if (ABPersonHasImageData(aLinkedRecord)) {
+            person = aLinkedRecord;
+            break;
+        }
+    }
+
     CFDataRef photoDataRef = ABPersonCopyImageDataWithFormat(person, kABPersonImageFormatThumbnail);
     if(!photoDataRef){
-      return nil;
+      return @"";
     }
 
     NSData* data = (__bridge_transfer NSData*)photoDataRef;


### PR DESCRIPTION
This addresses issue #11, which is a crash caused by `getABPersonThumbnailFilepath` returning `nil`.

`ABPersonHasImageData` can return `true` even if the contact has no image. This is because Apple Contacts allows you to link one or more contacts together.

What this PR does is makes `getABPersonThumbnailFilepath` scan through a contact’s linked people with `ABPersonCopyArrayOfAllLinkedPeople`, and find the one that _does_ have an icon, and use that.

And if that fails, it now returns `@""` and doesn't crash.
