### PR TITLE
Fix bug involving unused var

### DIFF
--- a/RCTAddressBook.m
+++ b/RCTAddressBook.m
@@ -174,8 +174,8 @@ withCallback:(RCTResponseSenderBlock) callback
         if (aLinkedPerson == person) {
             continue; // skip the original one
         }
-        if (ABPersonHasImageData(aLinkedRecord)) {
-            person = aLinkedRecord;
+        if (ABPersonHasImageData(aLinkedPerson)) {
+            person = aLinkedPerson;
             break;
         }
     }


### PR DESCRIPTION
This one’s totally on me: I forgot to push this commit that will stop any app using react-native-addressbook from building. 😬

Really ashamed about this, apologies again!
